### PR TITLE
Cool idea, fixed it so that your install process works

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ It grabs the last 100 issues(by default), then averages their lifespan by using 
 
 1. `clone the repo`
 2. `npm install`
-3. `node stats.js`
-
-Edit `stats.js` to point at a different repository
+3. `node stats.js apiengine/github-stats`
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
-  "dependencies": {
+  "name": "github-stats",
+  "version": "0.0.1",
+  "dependencies" : {
     "lodash": "~0.9.2",
     "superagent": "~0.10.0"
   }

--- a/stats.js
+++ b/stats.js
@@ -1,7 +1,8 @@
 var request = require('superagent');
 var _ = require('lodash');
 
-var repo = 'twitter/bootstrap';
+var repo = process.argv[2] || 'twitter/bootstrap';
+console.log("Using repo: " + repo);
 var totalIssuesChecked = 100;
 
 request.get('https://api.github.com/repos/' + repo + '/issues?state=closed&per_page=' + totalIssuesChecked, function(res){
@@ -10,7 +11,7 @@ request.get('https://api.github.com/repos/' + repo + '/issues?state=closed&per_p
   _.each(issues, function (issue) {
     var time = new Date(issue.closed_at).getTime()*1 - new Date(issue.created_at).getTime()*1 ;
     totaltime += time;
-  })
+  });
   var averageHours  = Math.round(totaltime/1000/issues.length / (60 * 60) * 100)/100;
   var averageDays = Math.round(averageHours / 24 * 100)/100;
   console.log('Average hours:', averageHours);


### PR DESCRIPTION
At least with npm==1.1.65 and node==0.8.14, `npm install` doesn't work.
